### PR TITLE
Code updates for the new analyzer.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(AnalysisTools)
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.6)
 
 set(AnalysisTools_DIR "${PROJECT_SOURCE_DIR}")
 include("${AnalysisTools_DIR}/cmake/include/common.cmake")

--- a/Core/include/AnalyzerData.h
+++ b/Core/include/AnalyzerData.h
@@ -109,6 +109,27 @@ public:
     }
     const HistContainer& GetHistograms() const { return histograms; }
 
+    template<typename Histogram>
+    std::map<std::string, std::shared_ptr<SmartHistogram<Histogram>>> GetHistogramsEx() const
+    {
+        std::map<std::string, std::shared_ptr<SmartHistogram<Histogram>>> result;
+        for(const auto& hist_entry : histograms) {
+            auto smart_hist = std::dynamic_pointer_cast<SmartHistogram<Histogram>>(hist_entry.second);
+            if(smart_hist)
+                result[hist_entry.first] = smart_hist;
+        }
+        return result;
+    }
+
+    template<typename Histogram>
+    std::shared_ptr<SmartHistogram<Histogram>> TryGetHistogramEx(const std::string& name) const
+    {
+        if(!histograms.count(name))
+            return std::shared_ptr<SmartHistogram<Histogram>>();
+        const auto& hist = histograms.at(name);
+        return std::dynamic_pointer_cast<SmartHistogram<Histogram>>(hist);
+    }
+
     void AddEntry(Entry& entry)
     {
         if(entries.count(entry.Name()))

--- a/Core/include/SmartHistogram.h
+++ b/Core/include/SmartHistogram.h
@@ -80,7 +80,7 @@ public:
         ValueType branch_value;
         TBranch* branch;
         rootTree.SetBranchAddress("values", &branch_value, &branch);
-        Long64_t N = rootTree->GetEntries();
+        Long64_t N = rootTree.GetEntries();
         for(Long64_t n = 0; n < N; ++n) {
             rootTree.GetEntry(n);
             data.push_back(branch_value);

--- a/Core/include/SmartHistogram.h
+++ b/Core/include/SmartHistogram.h
@@ -46,6 +46,7 @@ template<typename ValueType>
 class Base1DHistogram : public AbstractHistogram {
 public:
     using const_iterator = typename std::deque<ValueType>::const_iterator;
+    using RootContainer = TTree;
 
     Base1DHistogram(const std::string& name) : AbstractHistogram(name) {}
 
@@ -73,6 +74,20 @@ public:
         root_ext::WriteObject(*rootTree);
     }
 
+    void CopyContent(TTree& rootTree)
+    {
+        data.clear();
+        ValueType branch_value;
+        TBranch* branch;
+        rootTree.SetBranchAddress("values", &branch_value, &branch);
+        Long64_t N = rootTree->GetEntries();
+        for(Long64_t n = 0; n < N; ++n) {
+            rootTree.GetEntry(n);
+            data.push_back(branch_value);
+        }
+        rootTree.ResetBranchAddress(branch);
+    }
+
 private:
     std::deque<ValueType> data;
 };
@@ -87,6 +102,7 @@ public:
     };
 
     using const_iterator = typename std::deque<Value>::const_iterator;
+    using RootContainer = TTree;
 
     Base2DHistogram(const std::string& name) : AbstractHistogram(name) {}
 
@@ -114,6 +130,22 @@ public:
             rootTree->Fill();
         }
         root_ext::WriteObject(*rootTree);
+    }
+
+    void CopyContent(TTree& rootTree)
+    {
+        data.clear();
+        NumberType branch_value_x, branch_value_y;
+        TBranch *branch_x, *branch_y;
+        rootTree.SetBranchAddress("x", &branch_value_x, &branch_x);
+        rootTree.SetBranchAddress("y", &branch_value_y, &branch_y);
+        Long64_t N = rootTree.GetEntries();
+        for(Long64_t n = 0; n < N; ++n) {
+            rootTree.GetEntry(n);
+            data.push_back(Value(branch_value_x, branch_value_y));
+        }
+        rootTree.ResetBranchAddress(branch_x);
+        rootTree.ResetBranchAddress(branch_y);
     }
 
 private:
@@ -182,6 +214,8 @@ public:
 template<>
 class SmartHistogram<TH1D> : public TH1D, public AbstractHistogram {
 public:
+    using RootContainer = TH1D;
+
     SmartHistogram(const std::string& name, int nbins, double low, double high)
         : TH1D(name.c_str(), name.c_str(), nbins, low, high), AbstractHistogram(name), store(true),
           use_log_y(false), max_y_sf(1), divide_by_bin_width(false) {}
@@ -272,6 +306,8 @@ private:
 template<>
 class SmartHistogram<TH2D> : public TH2D, public AbstractHistogram {
 public:
+    using RootContainer = TH2D;
+
     SmartHistogram(const std::string& name,
                    int nbinsx, double xlow, double xup,
                    int nbinsy, double ylow, double yup)
@@ -352,7 +388,9 @@ template<>
 class SmartHistogram<TGraph> : public AbstractHistogram {
 public:
     using DataVector = std::vector<double>;
+    using RootContainer = TGraph;
     using AbstractHistogram::AbstractHistogram;
+
 
     void AddPoint(double x, double y)
     {

--- a/Core/include/StatEstimators.h
+++ b/Core/include/StatEstimators.h
@@ -161,7 +161,7 @@ double Variance(const std::vector<Value>& x)
     if(x.size() <= 1)
         throw std::runtime_error("Can't estimate variance using a sample with less than 2 observations.");
     const size_t n = x.size();
-    const double x_mean = double(std::accumulate(x.begin(), x.end(), 0)) / n;
+    const double x_mean = double(std::accumulate(x.begin(), x.end(), Value(0))) / n;
     double var = 0;
     for(size_t k = 0; k < n; ++k)
         var += std::pow(x.at(k) - x_mean, 2);

--- a/Core/include/TextIO.h
+++ b/Core/include/TextIO.h
@@ -9,12 +9,33 @@ This file is part of https://github.com/hh-italian-group/AnalysisTools. */
 
 namespace analysis {
 
+namespace detail {
+template<typename T, typename CharT>
+struct ToStringImpl {
+    static std::basic_string<CharT> ToString(const T& t)
+    {
+        std::basic_ostringstream<CharT> ss;
+        ss << t;
+        return ss.str();
+    }
+};
+
+template<typename CharT>
+struct ToStringImpl<std::basic_string<CharT>, CharT> {
+    static std::basic_string<CharT> ToString(const std::basic_string<CharT>& str) { return str; }
+};
+
+template<typename CharT, int N>
+struct ToStringImpl<const CharT[N], CharT> {
+    static std::basic_string<CharT> ToString(const CharT str[N]) { return str; }
+};
+
+} // namespace detail
+
 template<typename T, typename CharT = char>
-std::basic_string<CharT> ToString(const T& t)
+std::basic_string<CharT> ToString(T&& t)
 {
-    std::basic_ostringstream<CharT> ss;
-    ss << t;
-    return ss.str();
+    return detail::ToStringImpl<typename std::remove_reference<T>::type, CharT>::ToString(std::forward<T>(t));
 }
 
 template<typename T, typename CharT>

--- a/Core/test/AnalyzerData_t.cxx
+++ b/Core/test/AnalyzerData_t.cxx
@@ -15,8 +15,11 @@ struct MyAnaData : public root_ext::AnalyzerData {
         other_hist.SetMasterHist(5, 5, 10);
     }
 
+    const std::vector<double> bins{1, 2, 3, 4};
+
     TH1D_ENTRY(hist, 10, .5, 10.5)
     ANA_DATA_ENTRY(TH1D, other_hist)
+    TH1D_ENTRY_CUSTOM(custom_hist, bins)
 };
 
 struct Arguments {
@@ -35,6 +38,10 @@ public:
         anaData.hist(1).Fill(4);
         anaData.hist("z").Fill(21.5);
         anaData.other_hist(0).Fill(6);
+        std::string f = "f";
+        anaData.custom_hist().Fill(3.5);
+        anaData.custom_hist(f).Fill(2.4);
+        anaData.custom_hist(std::string("g")).Fill(1.5);
     }
 
 private:

--- a/Print/include/RootPrintSource.h
+++ b/Print/include/RootPrintSource.h
@@ -11,14 +11,14 @@ This file is part of https://github.com/hh-italian-group/AnalysisTools. */
 namespace root_ext {
 
 struct PageSideLayout {
-    Box main_pad;
+    Box<double> main_pad;
     bool has_stat_pad;
-    Box stat_pad;
+    Box<double> stat_pad;
     bool has_legend;
     bool has_legend_pad;
-    Box legend_pad;
+    Box<double> legend_pad;
     bool has_ratio_pad;
-    Box ratio_pad;
+    Box<double> ratio_pad;
 };
 
 struct PageSide {
@@ -31,14 +31,14 @@ struct PageSide {
     bool use_log_scaleY;
     bool fit_range_x;
     bool fit_range_y;
-    Range xRange;
-    Range yRange;
+    analysis::Range<double> xRange;
+    analysis::Range<double> yRange;
     PageSideLayout layout;
 };
 
 struct PageLayout {
     bool has_title;
-    Box title_box;
+    Box<double> title_box;
     Font_t title_font;
     std::string global_style;
     Int_t stat_options;
@@ -60,7 +60,7 @@ struct SingleSidedPage : public Page {
     explicit SingleSidedPage(bool has_title = true, bool has_stat_pad = true, bool has_legend = true)
     {
         layout.has_title = has_title;
-        layout.title_box = Box(0.1, 0.94, 0.9, 0.98);
+        layout.title_box = Box<double>(0.1, 0.94, 0.9, 0.98);
         layout.title_font = 52;
         layout.global_style = "Plain";
         if(has_stat_pad) {
@@ -78,9 +78,9 @@ struct SingleSidedPage : public Page {
         side.fit_range_x = true;
         side.fit_range_y = true;
 
-        side.layout.main_pad = Box(0.01, 0.01, 0.85, 0.91);
-        side.layout.stat_pad = Box(0.86, 0.01, 0.99, 0.91);
-        side.layout.legend_pad = Box(0.5, 0.67, 0.88, 0.88);
+        side.layout.main_pad = Box<double>(0.01, 0.01, 0.85, 0.91);
+        side.layout.stat_pad = Box<double>(0.86, 0.01, 0.99, 0.91);
+        side.layout.legend_pad = Box<double>(0.5, 0.67, 0.88, 0.88);
     }
 
     virtual RegionCollection Regions() const
@@ -97,7 +97,7 @@ struct DoubleSidedPage : public Page {
     explicit DoubleSidedPage(bool has_title = true, bool has_stat_pad = true, bool has_legend = true)
     {
         layout.has_title = has_title;
-        layout.title_box = Box(0.1, 0.94, 0.9, 0.98);
+        layout.title_box = Box<double>(0.1, 0.94, 0.9, 0.98);
         layout.title_font = 52;
         layout.global_style = "Plain";
         if(has_stat_pad) {
@@ -114,9 +114,9 @@ struct DoubleSidedPage : public Page {
         left_side.use_log_scaleY = false;
         left_side.fit_range_x = true;
         left_side.fit_range_y = true;
-        left_side.layout.main_pad = Box(0.01, 0.01, 0.35, 0.91);
-        left_side.layout.stat_pad = Box(0.36, 0.01, 0.49, 0.91);
-        left_side.layout.legend_pad = Box(0.5, 0.67, 0.88, 0.88);
+        left_side.layout.main_pad = Box<double>(0.01, 0.01, 0.35, 0.91);
+        left_side.layout.stat_pad = Box<double>(0.36, 0.01, 0.49, 0.91);
+        left_side.layout.legend_pad = Box<double>(0.5, 0.67, 0.88, 0.88);
 
         right_side.layout.has_stat_pad = has_stat_pad;
         right_side.layout.has_legend = has_legend;
@@ -124,9 +124,9 @@ struct DoubleSidedPage : public Page {
         right_side.use_log_scaleY = false;
         right_side.fit_range_x = true;
         right_side.fit_range_y = true;
-        right_side.layout.main_pad = Box(0.51, 0.01, 0.85, 0.91);
-        right_side.layout.stat_pad = Box(0.86, 0.01, 0.99, 0.91);
-        right_side.layout.legend_pad = Box(0.5, 0.67, 0.88, 0.88);
+        right_side.layout.main_pad = Box<double>(0.51, 0.01, 0.85, 0.91);
+        right_side.layout.stat_pad = Box<double>(0.86, 0.01, 0.99, 0.91);
+        right_side.layout.legend_pad = Box<double>(0.5, 0.67, 0.88, 0.88);
     }
 
     virtual RegionCollection Regions() const
@@ -152,12 +152,12 @@ public:
         static std::vector<PlotOptions> options;
         if(!options.size())
         {
-            options.push_back( PlotOptions(kGreen, 1, root_ext::Box(0.01, 0.71, 0.99, 0.9), 0.1, kGreen, 2) );
-            options.push_back( PlotOptions(kViolet, 1, root_ext::Box(0.01, 0.51, 0.99, 0.7), 0.1, kViolet, 2) );
-            options.push_back( PlotOptions(kOrange, 1, root_ext::Box(0.01, 0.31, 0.99, 0.5), 0.1, kOrange, 2) );
-            options.push_back( PlotOptions(kRed, 1, root_ext::Box(0.01, 0.11, 0.99, 0.3), 0.1, kRed, 2) );
-            options.push_back( PlotOptions(kBlue, 1, root_ext::Box(0.01, 0.11, 0.99, 0.3), 0.1, kBlue, 2) );
-            options.push_back( PlotOptions(kBlack, 1, root_ext::Box(0.01, 0.11, 0.99, 0.3), 0.1, kBlack, 2) );
+            options.push_back( PlotOptions(kGreen, 1, root_ext::Box<double>(0.01, 0.71, 0.99, 0.9), 0.1, kGreen, 2) );
+            options.push_back( PlotOptions(kViolet, 1, root_ext::Box<double>(0.01, 0.51, 0.99, 0.7), 0.1, kViolet, 2) );
+            options.push_back( PlotOptions(kOrange, 1, root_ext::Box<double>(0.01, 0.31, 0.99, 0.5), 0.1, kOrange, 2) );
+            options.push_back( PlotOptions(kRed, 1, root_ext::Box<double>(0.01, 0.11, 0.99, 0.3), 0.1, kRed, 2) );
+            options.push_back( PlotOptions(kBlue, 1, root_ext::Box<double>(0.01, 0.11, 0.99, 0.3), 0.1, kBlue, 2) );
+            options.push_back( PlotOptions(kBlack, 1, root_ext::Box<double>(0.01, 0.11, 0.99, 0.3), 0.1, kBlack, 2) );
         }
         return n < options.size() ? options[n] : options[options.size() - 1];
     }

--- a/Print/include/StackedPlotDescriptor.h
+++ b/Print/include/StackedPlotDescriptor.h
@@ -42,18 +42,18 @@ public:
         page.layout.has_title = draw_title;
         if (draw_ratio){
             if (page.layout.has_title) {
-                page.side.layout.main_pad = root_ext::Box(0.02,0.19,0.95,0.94);
-                page.side.layout.ratio_pad = root_ext::Box(0.02,0.02,1,0.28);
+                page.side.layout.main_pad = root_ext::Box<double>(0.02,0.19,0.95,0.94);
+                page.side.layout.ratio_pad = root_ext::Box<double>(0.02,0.02,1,0.28);
             } else {
-                page.side.layout.main_pad = root_ext::Box(0.02,0.21,1,1);
-                page.side.layout.ratio_pad = root_ext::Box(0.02,0.02,1,0.30);
+                page.side.layout.main_pad = root_ext::Box<double>(0.02,0.21,1,1);
+                page.side.layout.ratio_pad = root_ext::Box<double>(0.02,0.02,1,0.30);
             }
         }
         else {
             if (page.layout.has_title) {
-                page.side.layout.main_pad = root_ext::Box(0.02,0.02,0.95,0.94);
+                page.side.layout.main_pad = root_ext::Box<double>(0.02,0.02,0.95,0.94);
             } else {
-                page.side.layout.main_pad = root_ext::Box(0.,0., 1, 1);
+                page.side.layout.main_pad = root_ext::Box<double>(0.,0., 1, 1);
             }
         }
 
@@ -106,10 +106,11 @@ public:
 
     const std::string& GetTitle() const { return page.title; }
 
-    void AddBackgroundHistogram(const Histogram& original_histogram, const std::string& legend_title, Color_t color)
+    void AddBackgroundHistogram(const Histogram& original_histogram, const std::string& legend_title,
+                                const root_ext::Color& color)
     {
         hist_ptr histogram = PrepareHistogram(original_histogram);
-        histogram->SetFillColor(color);
+        histogram->SetFillColor(static_cast<Color_t>(color.GetColorId()));
         histogram->SetFillStyle(1001);
         histogram->SetLegendTitle(legend_title);
         background_histograms.push_back(histogram);
@@ -123,8 +124,8 @@ public:
             sum_backgound_histogram->Add(histogram.get());
     }
 
-    void AddSignalHistogram(const Histogram& original_signal, const std::string& legend_title, Color_t color,
-                            unsigned scale_factor)
+    void AddSignalHistogram(const Histogram& original_signal, const std::string& legend_title,
+                            const root_ext::Color& color, double scale_factor)
     {
         hist_ptr histogram = PrepareHistogram(original_signal);
         //Reb
@@ -133,7 +134,7 @@ public:
         histogram->SetLineStyle(2);
         histogram->SetFillColor(0);
 		//histogram->SetLineColor(kBlue+3);
-        histogram->SetLineColor(color);
+        histogram->SetLineColor(static_cast<Color_t>(color.GetColorId()));
         histogram->SetLineWidth(3);
         //ours
         //histogram->SetLineColor(color);
@@ -370,7 +371,7 @@ private:
     hist_ptr PrepareHistogram(const Histogram& original_histogram)
     {
         hist_ptr histogram(new Histogram(original_histogram));
-        histogram->SetLineColor(root_ext::colorMapName.at("black"));
+        histogram->SetLineColor(kBlack);
         histogram->SetLineWidth(1.);
         if (histogram->NeedToDivideByBinWidth())
             ReweightWithBinWidth(histogram);

--- a/Print/source/Print_Histogram.cxx
+++ b/Print/source/Print_Histogram.cxx
@@ -88,7 +88,7 @@ private:
     std::vector<FileTagPair> inputs;
     root_ext::SingleSidedPage page;
     Printer printer;
-    root_ext::Range xRange;
+    analysis::Range<double> xRange;
     MyHistogramSource source;
 };
 

--- a/Print/source/Print_SmartHistogram.cxx
+++ b/Print/source/Print_SmartHistogram.cxx
@@ -9,7 +9,7 @@ This file is part of https://github.com/hh-italian-group/AnalysisTools. */
 
 class MyHistogramSource : public root_ext::HistogramSource<TH1D, Double_t, TTree> {
 public:
-    MyHistogramSource(const root_ext::Range& _xRange, unsigned _nBins)
+    MyHistogramSource(const analysis::Range<double>& _xRange, unsigned _nBins)
         : xRange(_xRange), nBins(_nBins) {}
 protected:
     virtual TH1D* Convert(TTree* tree) const
@@ -19,13 +19,13 @@ protected:
         const std::string name = s_name.str();
         const std::string command = "values>>+" + name;
 
-        TH1D* histogram = new TH1D(name.c_str(), name.c_str(), static_cast<int>(nBins), xRange.min, xRange.max);
+        TH1D* histogram = new TH1D(name.c_str(), name.c_str(), static_cast<int>(nBins), xRange.min(), xRange.max());
         tree->Draw(command.c_str(), "");
         return histogram;
     }
 
 private:
-    root_ext::Range xRange;
+    analysis::Range<double> xRange;
     unsigned nBins;
 };
 
@@ -95,7 +95,7 @@ private:
     std::vector<FileTagPair> inputs;
     root_ext::SingleSidedPage page;
     Printer printer;
-    root_ext::Range xRange;
+    analysis::Range<double> xRange;
     MyHistogramSource source;
 };
 

--- a/Print/source/Print_TreeBranch.cxx
+++ b/Print/source/Print_TreeBranch.cxx
@@ -9,7 +9,7 @@ This file is part of https://github.com/hh-italian-group/AnalysisTools. */
 
 class MyHistogramSource : public root_ext::HistogramSource<TH1D, Double_t, TTree> {
 public:
-    MyHistogramSource(const std::string& _branchName, const root_ext::Range& _xRange, unsigned _nBins)
+    MyHistogramSource(const std::string& _branchName, const analysis::Range<double>& _xRange, unsigned _nBins)
         : branchName(_branchName), xRange(_xRange), nBins(_nBins) {}
 protected:
     virtual TH1D* Convert(TTree* tree) const
@@ -17,14 +17,14 @@ protected:
         const std::string name = branchName + "_hist";
         const std::string command = branchName + ">>+" + name;
 
-        TH1D* histogram = new TH1D(name.c_str(), name.c_str(), static_cast<int>(nBins), xRange.min, xRange.max);
+        TH1D* histogram = new TH1D(name.c_str(), name.c_str(), static_cast<int>(nBins), xRange.min(), xRange.max());
         tree->Draw(command.c_str(), "");
         return histogram;
     }
 
 private:
     std::string branchName;
-    root_ext::Range xRange;
+    analysis::Range<double> xRange;
     unsigned nBins;
 };
 
@@ -98,7 +98,7 @@ private:
     std::vector<FileTagPair> inputs;
     root_ext::SingleSidedPage page;
     Printer printer;
-    root_ext::Range xRange;
+    analysis::Range<double> xRange;
     MyHistogramSource source;
 };
 

--- a/Run/include/program_main.h
+++ b/Run/include/program_main.h
@@ -9,6 +9,7 @@ This file is part of https://github.com/hh-italian-group/AnalysisTools. */
 #include <boost/program_options.hpp>
 #include <TROOT.h>
 #include <TH1.h>
+#include <TH2.h>
 
 #define REQ_ARG(type, name) run::Argument<type> name{#name, ""}
 #define OPT_ARG(type, name, default_value) run::Argument<type> name{#name, "", default_value}
@@ -68,6 +69,8 @@ int Main(int argc, char* argv[], const Options& options, const options_descripti
 
     try {
         TH1::SetDefaultSumw2();
+        TH1::AddDirectory(kFALSE);
+        TH2::AddDirectory(kFALSE);
         gROOT->ProcessLine("#include <vector>");
         gROOT->SetMustClean(kFALSE);
         if(!ParseProgramArguments(argc, argv, options_desc, pos_desc))


### PR DESCRIPTION
- Requiring CMake 3.6.
- AnalyzerData:
  - implemented read mode;
  - added methods GetHistogramsEx and TryGetHistogramsEx.
- ConfigReader: added method ParseMappedEntryList.
- SmartHistogram: added method CopyContent to all SmartHistogram specialisations.
- StatEstimators: fixed bug with double/integer type support in function Variance.
- TextIO: improved ToString performance for std::string and const char*.
- Printing code: fixed compilation errors.
- program_main.h: set AddDirectory to false for TH1 and TH2.